### PR TITLE
Set up Spotless for Markdown with Flexmark, apply to README (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ The server should be running at http://localhost:8080/.
 - [Webpack](https://webpack.js.org/concepts/)
 - [HtmlUnit](https://www.htmlunit.org/gettingStarted.html)
 - [Spotless](https://github.com/diffplug/spotless/tree/main/plugin-gradle)
+

--- a/build.gradle
+++ b/build.gradle
@@ -80,13 +80,18 @@ spotless {
         jackson()
     }
 
+    flexmark {
+        target '*.md', 'src/**/*.md'
+        flexmark()
+    }
+
     format 'prettier', {
         target 'src/**/*.js', 'webpack.config.js', 'src/**/*.json', 'package.json', 'src/**/*.css', 'src/**/*.scss', 'src/**/*.html'
         prettier().config(['tabWidth': 4, 'printWidth': 100, 'bracketSameLine': true])
     }
 
     format 'misc', {
-        target '*.gradle', '*.md', '.gitignore'
+        target '*.gradle', '.gitignore'
         trimTrailingWhitespace()
         leadingTabsToSpaces()
         endWithNewline()


### PR DESCRIPTION
Will resolve #3.

Run and apply with `spotlessCheck` and `spotlessApply`, see also:

https://github.com/hbz/lobid-gnd-ui?tab=readme-ov-file#run-checks

Uses Flexmark support from the Spotless Gradle plugin with default settings, see:

https://github.com/diffplug/spotless/tree/main/plugin-gradle#flexmark

This doesn't cover the specific examples from #3, but it improves consistency and catches errors.